### PR TITLE
Fix inconsistency and missing argument

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -74,9 +74,9 @@ contributors: Zibi Braniecki, Daniel Ehrenberg
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _formats_ be _dataLocaleData_.[[formats]].
-        1. <ins>Let _dateStyle_ be ? GetOption(_options_, `"dateStyle"`, `"string"`, &laquo; `"full"`, `"long"`, `"medium"`, `"short"` &raquo;).</ins>
+        1. <ins>Let _dateStyle_ be ? GetOption(_options_, `"dateStyle"`, `"string"`, &laquo; `"full"`, `"long"`, `"medium"`, `"short"` &raquo;, *undefined*).</ins>
         1. <ins>If _dateStyle_ is not *undefined*, set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.</ins>
-        1. <ins>Let _timeStyle_ be ? GetOption(_options_, `"timeStyle"`, `"string"`, &laquo; `"full"`, `"long"`, `"medium"`, `"short"` &raquo;).</ins>
+        1. <ins>Let _timeStyle_ be ? GetOption(_options_, `"timeStyle"`, `"string"`, &laquo; `"full"`, `"long"`, `"medium"`, `"short"` &raquo;, *undefined*).</ins>
         1. <ins>If _timeStyle_ is not *undefined*, set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.</ins>
         1. <ins>If _dateStyle_ or _timeStyle_ are not *undefined*, then</ins>
           1. <ins>Let _pattern_ be DateTimeStylePattern(_dateStyle_, _timeStyle_, _dataLocaleData_, _hourCycle_).</ins>
@@ -127,17 +127,17 @@ contributors: Zibi Braniecki, Daniel Ehrenberg
     </emu-clause>
     <emu-clause id="sec-date-time-style-pattern" aoid="DateTimeStylePattern">
       <h1>DateTimeStylePattern ( _dateStyle_, _timeStyle_, _dataLocaleData_, _hourCycle_ )</h1>
-      <p>The DateTimeStylePattern abstract operation accepts arguments _dateStyle_ and _timeStyle_, which are each either *undefined*, `"full"`, `"long"`, `"short"` or `"narrow"`, at least one of which is not *undefined*, _dataLocaleData_, which is a record from %DateTimeFormat%.[[LocaleData]][_locale_] for some locale _locale_, and _hourCycle_, which is either `"h11"`, `"h12"`, `"h23"`, or `"h24"`. It returns the appropriate pattern for date time formatting based on the parameters.</p>
+      <p>The DateTimeStylePattern abstract operation accepts arguments _dateStyle_ and _timeStyle_, which are each either *undefined*, `"full"`, `"long"`, `"medium"` or `"short"`, at least one of which is not *undefined*, _dataLocaleData_, which is a record from %DateTimeFormat%.[[LocaleData]][_locale_] for some locale _locale_, and _hourCycle_, which is either `"h11"`, `"h12"`, `"h23"`, or `"h24"`. It returns the appropriate pattern for date time formatting based on the parameters.</p>
       <emu-alg>
         1. If _timeStyle_ is not *undefined*,
-          1. Assert: _timeStyle_ is one of `"full"`, `"long"`, `"short"` or `"narrow"`.
+          1. Assert: _timeStyle_ is one of `"full"`, `"long"`, `"medium"` or `"short"`.
           1. Let _timeFormats_ be _dataLocaleData_.[[TimeFormat]].[[&lt;_timeStyle_&gt;]].
           1. If _hourCycle_ is `"h11"` or `"h12"`, then
             1. Let _timeFormat_ be _timeFormats_.[[pattern12]].
           1. Else,
             1. Let _timeFormat_ be _timeFormats_.[[pattern]].
         1. If _dateStyle_ is not *undefined*,
-          1. Assert: _dateStyle_ is one of `"full"`, `"long"`, `"short"` or `"narrow"`.
+          1. Assert: _dateStyle_ is one of `"full"`, `"long"`, `"medium"` or `"short"`.
           1. Let _dateFormat_ _dataLocaleData_.[[DateFormat]].[[&lt;_dateStyle_&gt;]].
         1. If _dateStyle_ is not *undefined* and _timeStyle_ is not *undefined*,
           1. Let _connector_ be _dataLocaleData_.[[DateTimeFormat]].[[&lt;_dateStyle_&gt;]].
@@ -227,7 +227,7 @@ contributors: Zibi Braniecki, Daniel Ehrenberg
           Each of the records must also have a pattern field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with `"{"`, followed by the name of the field, followed by `"}"`. If the record has an hour field, it must also have a pattern12 field, whose value is a String value that, in addition to the substrings of the pattern field, contains a substring `"{ampm}"`.
         </li>
         <li>
-          [[LocaleData]][locale] must contain [[DateFormat]], [[TimeFormat]] and [[DateTimeFormat]] fields, each of which has [[full]], [[long]], [[short]] and [[narrow]] fields. These fields have string pattern values for [[DateFormat]] and [[DateTimeFormat]]; for [[TimeFormat]], they are records with [[pattern]] and [[pattern12]] fields, which are string patterns.
+          [[LocaleData]][locale] must contain [[DateFormat]], [[TimeFormat]] and [[DateTimeFormat]] fields, each of which has [[full]], [[long]], [[medium]] and [[short]] fields. These fields have string pattern values for [[DateFormat]] and [[DateTimeFormat]]; for [[TimeFormat]], they are records with [[pattern]] and [[pattern12]] fields, which are string patterns.
         </li>
       </ul>
 


### PR DESCRIPTION
1. Change the DateTimeStylePattern from ... "short", "narrow" ... to  ... "medium", "short" ... to align with other places
2. add the missing undefined argument as the last argument to GetOption() of "dateStyle" and "timeStyle"

@zbraniecki @littledan 