### PR TITLE
Correct stage and sync with latest ECMA402 draft

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -371,7 +371,7 @@ contributors: Zibi Braniecki, Daniel Ehrenberg
     <p>
       Objects that have been successfully initialized as a DateTimeFormat also have several internal slots that are computed by the constructor:
     </p>
-   
+
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Calendar]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the calendar used for formatting.</li>

--- a/spec.html
+++ b/spec.html
@@ -1,7 +1,7 @@
 <pre class="metadata">
 title: dateStyle and timeStyle options for DateTimeFormat
 status: proposal
-stage: 1
+stage: 2
 location: https://tc39.github.io/proposal-ecma402-datetime-style/
 copyright: false
 contributors: Zibi Braniecki, Daniel Ehrenberg
@@ -164,7 +164,7 @@ contributors: Zibi Braniecki, Daniel Ehrenberg
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%DateTimeFormatPrototype%"`, &laquo; [[InitializedIntlObject]], [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]], [[Hour12]], [[HourNo0]], <ins>[[DateStyle]], [[TimeStyle]],</ins> [[Pattern]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%DateTimeFormatPrototype%"`, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]], [[HourCycle]], <ins>[[DateStyle]], [[TimeStyle]],</ins> [[Pattern]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
@@ -371,17 +371,15 @@ contributors: Zibi Braniecki, Daniel Ehrenberg
     <p>
       Objects that have been successfully initialized as a DateTimeFormat also have several internal slots that are computed by the constructor:
     </p>
-
+   
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[Calendar]] is a String value with the "type" given in Unicode Technical Standard 35 for the calendar used for formatting.</li>
-      <li>[[NumberingSystem]] is a String value with the "type" given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
+      <li>[[Calendar]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the calendar used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
       <li>[[TimeZone]] is a String value with the IANA time zone name of the time zone used for formatting.</li>
       <li>[[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]] are each either *undefined*, indicating that the component is not used for formatting, or one of the String values given in <emu-xref href="#table-datetimeformat-components"></emu-xref>, indicating how the component should be presented in the formatted output.</li>
-      <li>[[Hour12]] is a Boolean value indicating whether 12-hour format (*true*) or 24-hour format (*false*) should be used. It is only used when [[Hour]] is not *undefined*.</li>
-      <li>[[HourNo0]] is a Boolean value indicating whether hours from 1 to 12 (*true*) or from 0 to 11 (*false*) should be used. It is only used when [[Hour12]] has the value *true*.</li>
-      <li><ins>[[DateStyle]] is a String value with values `"full"`, `"long"`, `"medium"` or `"short"`.</ins></li>
-      <li><ins>[[TimeStyle]] is a String value with values `"full"`, `"long"`, `"medium"` or `"short"`.</ins></li>
+      <li>[[HourCycle]] is a String value indicating whether the 12-hour format (`"h11"`, `"h12"`) or the 24-hour format (`"h23"`, `"h24"`) should be used. `"h11"` and `"h23"` start with hour 0 and go up to 11 and 23 respectively. `"h12"` and `"h24"` start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
+      <li><ins>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values `"full"`, `"long"`, `"medium"` or `"short"`.</ins></li>
       <li>[[Pattern]] is a String value as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
     </ul>
   </emu-clause>


### PR DESCRIPTION
1. Correct stage to 2 (since Oct 2018) 
2. Clarify [[DateStyle]] and [[TimeStyle]] could have undefined in section "1.5 Properties of Intl.DateTimeFormat Instances"
3. Remove [[InitializedIntlObject]], [[Hour12]] and [[HourNo0]]  which are not in current draft of ECMA 402 from "1.5 Properties of Intl.DateTimeFormat Instances" and "1.2.1 Intl.DateTimeFormat "